### PR TITLE
FIX broken FTP sources for PCRE and OpenSSL

### DIFF
--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,5 +1,5 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2r
+PKG_VERS = 1.0.2t
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
 PKG_DIST_SITE = ftp://ftp.openssl.org/source

--- a/cross/openssl/Makefile
+++ b/cross/openssl/Makefile
@@ -1,8 +1,8 @@
 PKG_NAME = openssl
-PKG_VERS = 1.0.2t
+PKG_VERS = 1.0.2r
 PKG_EXT = tar.gz
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = ftp://ftp.openssl.org/source
+PKG_DIST_SITE = https://www.openssl.org/source
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS = cross/zlib

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2r.tar.gz SHA1 b9aec1fa5cedcfa433aed37c8fe06b0ab0ce748d
-openssl-1.0.2r.tar.gz SHA256 ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
-openssl-1.0.2r.tar.gz MD5 0d2baaf04c56d542f6cc757b9c2a2aac
+openssl-1.0.2t.tar.gz SHA1 8ac3fd379cf8c8ef570abb51ec52a88fd526f88a
+openssl-1.0.2t.tar.gz SHA256 14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc
+openssl-1.0.2t.tar.gz MD5 ef66581b80f06eae42f5268bc0b50c6d

--- a/cross/openssl/digests
+++ b/cross/openssl/digests
@@ -1,3 +1,3 @@
-openssl-1.0.2t.tar.gz SHA1 8ac3fd379cf8c8ef570abb51ec52a88fd526f88a
-openssl-1.0.2t.tar.gz SHA256 14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc
-openssl-1.0.2t.tar.gz MD5 ef66581b80f06eae42f5268bc0b50c6d
+openssl-1.0.2r.tar.gz SHA1 b9aec1fa5cedcfa433aed37c8fe06b0ab0ce748d
+openssl-1.0.2r.tar.gz SHA256 ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
+openssl-1.0.2r.tar.gz MD5 0d2baaf04c56d542f6cc757b9c2a2aac

--- a/cross/pcre/Makefile
+++ b/cross/pcre/Makefile
@@ -2,7 +2,7 @@ PKG_NAME = pcre
 PKG_VERS = 8.39
 PKG_EXT = tar.bz2
 PKG_DIST_NAME = $(PKG_NAME)-$(PKG_VERS).$(PKG_EXT)
-PKG_DIST_SITE = ftp://ftp.csx.cam.ac.uk/pub/software/programming/$(PKG_NAME)
+PKG_DIST_SITE = ftp://ftp.pcre.org/pub/$(PKG_NAME)
 PKG_DIR = $(PKG_NAME)-$(PKG_VERS)
 
 DEPENDS =


### PR DESCRIPTION
Compilation was failing due to defunct sources for PCRE and OpenSSL. Now corrected with this fix.
